### PR TITLE
Phase 1.2: Card Redesign — hover effects, relative time, channel avatars

### DIFF
--- a/src/components/video/ChannelCard.jsx
+++ b/src/components/video/ChannelCard.jsx
@@ -5,8 +5,24 @@ import { Link } from 'react-router-dom';
 
 import { demoProfilePicture } from '../../utils/constants';
 
+const abbreviateNumber = (num) => {
+  if (!num) {
+    return null;
+  }
+  const n = parseInt(num, 10);
+  if (n >= 1000000) {
+    return (n / 1000000).toFixed(1).replace(/\.0$/, '') + 'M';
+  }
+  if (n >= 1000) {
+    return (n / 1000).toFixed(1).replace(/\.0$/, '') + 'K';
+  }
+  return n.toLocaleString();
+};
+
 const ChannelCard = ({ channelDetail, marginTop }) => {
   const channelId = channelDetail?.id?.channelId || channelDetail?.id;
+  const title = channelDetail?.snippet?.title;
+  const subscriberCount = channelDetail?.statistics?.subscriberCount;
 
   return (
     <Box
@@ -20,11 +36,15 @@ const ChannelCard = ({ channelDetail, marginTop }) => {
         height: '326px',
         margin: 'auto',
         marginTop,
+        transition: 'transform 0.3s ease, box-shadow 0.3s ease',
+        '&:hover': {
+          transform: 'translateY(-4px)',
+        },
       }}
     >
       <Link
         to={`/channel/${channelId}`}
-        aria-label={`Open channel ${channelDetail?.snippet?.title || 'channel'}`}
+        aria-label={`Open channel ${title || 'channel'}`}
       >
         <CardContent
           sx={{
@@ -40,7 +60,7 @@ const ChannelCard = ({ channelDetail, marginTop }) => {
               channelDetail?.snippet?.thumbnails?.high?.url ||
               demoProfilePicture
             }
-            alt={channelDetail?.snippet?.title}
+            alt={title}
             sx={{
               borderRadius: '50%',
               height: '180px',
@@ -51,18 +71,15 @@ const ChannelCard = ({ channelDetail, marginTop }) => {
             }}
           />
           <Typography variant="h6">
-            {channelDetail?.snippet?.title}
+            {title}
             <CheckCircle
               aria-hidden="true"
               sx={{ fontSize: 12, color: 'custom.verifiedBadge', ml: '5px' }}
             />
           </Typography>
-          {channelDetail?.statistics?.subscriberCount && (
-            <Typography>
-              {parseInt(
-                channelDetail?.statistics?.subscriberCount
-              ).toLocaleString()}
-              Subscribers
+          {subscriberCount && (
+            <Typography variant="body2" color="text.secondary" sx={{ mt: 0.5 }}>
+              {abbreviateNumber(subscriberCount)} Subscribers
             </Typography>
           )}
         </CardContent>

--- a/src/components/video/VideoCard.jsx
+++ b/src/components/video/VideoCard.jsx
@@ -1,8 +1,16 @@
 import { Link } from 'react-router-dom';
 
-import { Card, CardContent, CardMedia, Typography } from '@mui/material';
+import {
+  Avatar,
+  Box,
+  Card,
+  CardContent,
+  CardMedia,
+  Typography,
+} from '@mui/material';
 import { CheckCircle } from '@mui/icons-material';
 
+import { formatRelativeTime } from '../../utils/formatRelativeTime';
 import {
   demoVideoUrl,
   demoVideoTitle,
@@ -16,53 +24,113 @@ const VideoCard = ({
     snippet,
   },
 }) => {
+  const title = snippet?.title || demoVideoTitle;
+  const channelTitle = snippet?.channelTitle || demoChannelTitle;
+  const channelId = snippet?.channelId;
+
   return (
     <Card
       sx={{
         width: { xs: '100%', sm: '358px', md: '320px' },
         boxShadow: 'none',
-        borderRadius: '0',
+        borderRadius: 0,
+        transition: 'transform 0.3s ease, box-shadow 0.3s ease',
+        '&:hover': {
+          transform: 'translateY(-4px)',
+          boxShadow: '0 8px 24px rgba(0,0,0,0.4)',
+        },
       }}
     >
       <Link
         to={videoId ? `/video/${videoId}` : demoVideoUrl}
-        aria-label={`Open video ${snippet?.title || demoVideoTitle}`}
+        aria-label={`Open video ${title}`}
       >
         <CardMedia
           image={snippet?.thumbnails?.high?.url}
           alt={snippet?.title}
-          sx={{ width: { xs: '100%', sm: '358px' }, height: 180 }}
+          sx={{
+            width: { xs: '100%', sm: '358px' },
+            height: 180,
+            transition: 'transform 0.3s ease',
+            '&:hover': {
+              transform: 'scale(1.05)',
+            },
+          }}
         />
       </Link>
-      <CardContent sx={{ bgcolor: 'background.paper', height: '106px' }}>
+      <CardContent
+        sx={{
+          bgcolor: 'background.paper',
+          height: 'auto',
+          minHeight: 100,
+          p: 1.5,
+          display: 'flex',
+          gap: 1.5,
+        }}
+      >
         <Link
-          to={videoId ? `/video/${videoId}` : demoVideoUrl}
-          aria-label={`Open video ${snippet?.title || demoVideoTitle}`}
+          to={channelId ? `/channel/${channelId}` : demoChannelUrl}
+          aria-label={`Open channel ${channelTitle}`}
+          sx={{ flexShrink: 0, height: 'fit-content' }}
         >
-          <Typography
-            variant="subtitle1"
-            fontWeight="bold"
-            color="text.primary"
+          <Avatar
+            alt={channelTitle}
+            sx={{
+              width: 36,
+              height: 36,
+              bgcolor: 'primary.main',
+              fontSize: 16,
+            }}
           >
-            {snippet?.title.slice(0, 60) || demoVideoTitle.slice(0, 60)}
-          </Typography>
+            {channelTitle.charAt(0).toUpperCase()}
+          </Avatar>
         </Link>
-        <Link
-          to={
-            snippet?.channelId
-              ? `/channel/${snippet?.channelId}`
-              : demoChannelUrl
-          }
-          aria-label={`Open channel ${snippet?.channelTitle || demoChannelTitle}`}
-        >
-          <Typography variant="subtitle2" fontWeight="bold" color="gray">
-            {snippet?.channelTitle || demoChannelTitle}
-          </Typography>
-          <CheckCircle
-            aria-hidden="true"
-            sx={{ fontSize: 12, color: 'custom.verifiedBadge', ml: '5px' }}
-          />
-        </Link>
+        <Box sx={{ minWidth: 0, flex: 1 }}>
+          <Link
+            to={videoId ? `/video/${videoId}` : demoVideoUrl}
+            aria-label={`Open video ${title}`}
+          >
+            <Typography
+              variant="subtitle2"
+              fontWeight="bold"
+              color="text.primary"
+              sx={{
+                display: '-webkit-box',
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: 'vertical',
+                overflow: 'hidden',
+                lineHeight: 1.3,
+                mb: 0.5,
+              }}
+            >
+              {title}
+            </Typography>
+          </Link>
+          <Link
+            to={channelId ? `/channel/${channelId}` : demoChannelUrl}
+            aria-label={`Open channel ${channelTitle}`}
+            sx={{ display: 'inline-flex', alignItems: 'center' }}
+          >
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              sx={{ mr: 0.5 }}
+            >
+              {channelTitle}
+            </Typography>
+            <CheckCircle
+              aria-hidden="true"
+              sx={{ fontSize: 12, color: 'custom.verifiedBadge' }}
+            />
+          </Link>
+          <Box>
+            {snippet?.publishedAt && (
+              <Typography variant="caption" color="text.secondary">
+                {formatRelativeTime(snippet.publishedAt)}
+              </Typography>
+            )}
+          </Box>
+        </Box>
       </CardContent>
     </Card>
   );

--- a/src/tests/fixtures/youtube.js
+++ b/src/tests/fixtures/youtube.js
@@ -5,6 +5,7 @@ export const newCategoryVideos = [
       title: 'Mock video title',
       channelId: 'channel-1',
       channelTitle: 'Mock channel',
+      publishedAt: new Date(Date.now() - 86400000 * 3).toISOString(),
       thumbnails: {
         high: {
           url: 'https://example.com/image.jpg',
@@ -21,6 +22,7 @@ export const codingCategoryVideos = [
       title: 'Coding deep dive',
       channelId: 'channel-2',
       channelTitle: 'Mock coding channel',
+      publishedAt: new Date(Date.now() - 86400000 * 7).toISOString(),
       thumbnails: {
         high: {
           url: 'https://example.com/coding.jpg',

--- a/src/utils/formatRelativeTime.js
+++ b/src/utils/formatRelativeTime.js
@@ -1,0 +1,30 @@
+const UNITS = [
+  { label: 'year', seconds: 31536000 },
+  { label: 'month', seconds: 2592000 },
+  { label: 'week', seconds: 604800 },
+  { label: 'day', seconds: 86400 },
+  { label: 'hour', seconds: 3600 },
+  { label: 'minute', seconds: 60 },
+];
+
+export const formatRelativeTime = (dateString) => {
+  const now = Date.now();
+  const then = new Date(dateString).getTime();
+  const seconds = Math.floor((now - then) / 1000);
+
+  if (seconds < 0) {
+    return 'just now';
+  }
+  if (seconds < 60) {
+    return 'just now';
+  }
+
+  for (const { label, seconds: unitSeconds } of UNITS) {
+    const count = Math.floor(seconds / unitSeconds);
+    if (count >= 1) {
+      return `${count} ${label}${count > 1 ? 's' : ''} ago`;
+    }
+  }
+
+  return 'just now';
+};


### PR DESCRIPTION
## Summary

Redesigns VideoCard and ChannelCard to match modern YouTube card patterns with hover effects, publish date display, and channel avatars.

## Changes

### New: `src/utils/formatRelativeTime.js`
- Converts ISO date to relative time (`3 days ago`, `2 weeks ago`, `1 year ago`)

### Redesigned: `VideoCard.jsx`
- **Hover lift**: `translateY(-4px)` + intensified shadow
- **Thumbnail zoom**: `scale(1.05)` on hover
- **Channel Avatar**: First-letter fallback via MUI Avatar, links to channel
- **Relative time**: Shows `snippet.publishedAt` below channel name
- **Two-column layout**: Avatar column + info column (title, channel, date)
- **Line clamp**: Title limited to 2 lines with ellipsis

### Improved: `ChannelCard.jsx`
- **Number abbreviation**: 1.2M / 50K / 300 (not raw integers)
- **Hover lift**: Same `translateY(-4px)` effect

### Updated: test fixtures
- Added `publishedAt` dates for relative time rendering
