### PR TITLE
Phase 1.3: Skeleton Redesign — card-shaped loading skeletons

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -9,6 +9,7 @@ export { default as ErrorState } from './shared/ErrorState';
 export { default as EmptyState } from './shared/EmptyState';
 export { default as AppErrorBoundary } from './shared/AppErrorBoundary';
 export { default as Sidebar } from './shared/Sidebar';
+export { default as VideoGridSkeleton } from './shared/VideoCardSkeleton';
 export { default as Videos } from './video/Videos';
 export { default as VideoCard } from './video/VideoCard';
 export { default as ChannelCard } from './video/ChannelCard';

--- a/src/components/routes/Feed.jsx
+++ b/src/components/routes/Feed.jsx
@@ -2,7 +2,7 @@ import { useCallback, useState } from 'react';
 import { Box, Stack, Typography } from '@mui/material';
 import { fetchSearchVideos } from '../../utils/fetchFromAPI';
 import { useAsyncResource } from '../../hooks';
-import { Sidebar, LoadingState, ErrorState, Videos } from '../';
+import { Sidebar, ErrorState, Videos, VideoGridSkeleton } from '../';
 
 const Feed = () => {
   const [selectedCategory, setSelectedCategory] = useState('New');
@@ -61,7 +61,7 @@ const Feed = () => {
           </Box>
         </Typography>
         {isLoading ? (
-          <LoadingState message={`Loading ${selectedCategory} videos...`} />
+          <VideoGridSkeleton count={8} />
         ) : errorMessage ? (
           <ErrorState
             title="Unable to load videos"

--- a/src/components/routes/SearchFeed.jsx
+++ b/src/components/routes/SearchFeed.jsx
@@ -3,7 +3,7 @@ import { useParams } from 'react-router-dom';
 import { Box, Typography } from '@mui/material';
 import { fetchSearchVideos } from '../../utils/fetchFromAPI';
 import { useAsyncResource } from '../../hooks';
-import { Videos, LoadingState, ErrorState } from '../';
+import { Videos, ErrorState, VideoGridSkeleton } from '../';
 
 const SearchFeed = () => {
   const { searchTerm } = useParams();
@@ -43,7 +43,7 @@ const SearchFeed = () => {
       </Typography>
 
       {isLoading ? (
-        <LoadingState message={`Searching for "${searchTerm}"...`} />
+        <VideoGridSkeleton count={8} />
       ) : errorMessage ? (
         <ErrorState
           title="Search failed"

--- a/src/components/shared/VideoCardSkeleton.jsx
+++ b/src/components/shared/VideoCardSkeleton.jsx
@@ -1,0 +1,78 @@
+import { Box, Card, CardContent, Skeleton, Stack } from '@mui/material';
+
+const VideoCardSkeleton = () => (
+  <Card
+    sx={{
+      width: { xs: '100%', sm: '358px', md: '320px' },
+      boxShadow: 'none',
+      borderRadius: 0,
+    }}
+  >
+    <Skeleton
+      variant="rectangular"
+      sx={{
+        width: { xs: '100%', sm: '358px' },
+        height: 180,
+        bgcolor: 'custom.skeletonDark',
+      }}
+    />
+    <CardContent
+      sx={{
+        bgcolor: 'background.paper',
+        height: 'auto',
+        minHeight: 100,
+        p: 1.5,
+        display: 'flex',
+        gap: 1.5,
+      }}
+    >
+      <Skeleton
+        variant="circular"
+        sx={{
+          width: 36,
+          height: 36,
+          bgcolor: 'custom.skeletonMid',
+          flexShrink: 0,
+        }}
+      />
+      <Box sx={{ minWidth: 0, flex: 1 }}>
+        <Stack spacing={0.8}>
+          <Skeleton
+            variant="rounded"
+            height={14}
+            sx={{ bgcolor: 'custom.skeletonLight' }}
+          />
+          <Skeleton
+            variant="rounded"
+            height={14}
+            width="60%"
+            sx={{ bgcolor: 'custom.skeletonLight' }}
+          />
+          <Skeleton
+            variant="rounded"
+            height={12}
+            width="40%"
+            sx={{ bgcolor: 'custom.skeletonMid', mt: 0.5 }}
+          />
+          <Skeleton
+            variant="rounded"
+            height={12}
+            width="25%"
+            sx={{ bgcolor: 'custom.skeletonMid' }}
+          />
+        </Stack>
+      </Box>
+    </CardContent>
+  </Card>
+);
+
+const VideoGridSkeleton = ({ count = 8 }) => (
+  <Stack direction="row" flexWrap="wrap" justifyContent="start" gap={2}>
+    {Array.from({ length: count }, (_, i) => (
+      <VideoCardSkeleton key={i} />
+    ))}
+  </Stack>
+);
+
+export { VideoCardSkeleton };
+export default VideoGridSkeleton;

--- a/src/tests/components/Feed.test.jsx
+++ b/src/tests/components/Feed.test.jsx
@@ -27,7 +27,9 @@ describe('Feed', () => {
   it('loads videos for the default category', async () => {
     renderWithRouter(<Feed />);
 
-    expect(screen.getByText('Loading New videos...')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { level: 1 })).toHaveTextContent(
+      /New.*videos/
+    );
 
     expect(await screen.findByText('Mock video title')).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary

Replace generic loading spinner + skeleton bars with card-shaped skeletons that mirror the redesigned VideoCard layout for better perceived performance.

## Changes

### New: `src/components/shared/VideoCardSkeleton.jsx`
- **VideoCardSkeleton**: Single skeleton card matching VideoCard dimensions
  - 16:9 thumbnail placeholder (rectangular)
  - Circular avatar skeleton (36px)
  - 4 text line skeletons (2 title + channel + date)
  - Colors from theme (`custom.skeletonLight/Mid/Dark`)
- **VideoGridSkeleton**: Renders `n` card skeletons in a flex-wrap grid (default 8)

### Updated route components
- **Feed.jsx**: Shows 8 card skeletons while loading
- **SearchFeed.jsx**: Shows 8 card skeletons while loading
- Detail pages (VideoDetail, ChannelDetail) still use `LoadingState` spinner


