### PR TITLE
Phase 1.4: Page Transitions — fade/slide route animations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@mui/icons-material": "^5.8.4",
         "@mui/material": "^5.9.3",
         "axios": "^1.17.0",
+        "framer-motion": "^12.41.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-player": "^2.10.1",
@@ -6324,6 +6325,33 @@
         "node": ">= 6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.41.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.41.0.tgz",
+      "integrity": "sha512-OHAMNiCEON1RDBlRGuulsN5AD8ptMjvk5QWfFmYmBLPZ3zFGIJe60kQucQQf4cez1OzQmjYBWDY+dYfISkUdqg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.41.0",
+        "motion-utils": "^12.39.0",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -8317,6 +8345,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/motion-dom": {
+      "version": "12.41.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.41.0.tgz",
+      "integrity": "sha512-Lk3J39fOGg6xNr1KRZsN6usDyBf8aP7MEbUPez1VCughHt79OrP7VGqNrPyFL0riaT7WS8t9DRw1M3BHtM/xKw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.39.0"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.39.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
+      "license": "MIT"
+    },
     "node_modules/mrmime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
@@ -10275,9 +10318,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD",
-      "optional": true
+      "license": "0BSD"
     },
     "node_modules/tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.9.3",
     "axios": "^1.17.0",
+    "framer-motion": "^12.41.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-player": "^2.10.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,14 +1,64 @@
 import { Suspense, lazy } from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom';
 import { Box, ThemeProvider } from '@mui/material';
 import CssBaseline from '@mui/material/CssBaseline';
-import { AppErrorBoundary, Navbar, LoadingState } from './components/';
+import { AnimatePresence } from 'framer-motion';
+import {
+  AppErrorBoundary,
+  Navbar,
+  LoadingState,
+  AnimatedPage,
+} from './components/';
 import { theme } from './themes/';
 
 const Feed = lazy(() => import('./components/routes/Feed'));
 const VideoDetail = lazy(() => import('./components/routes/VideoDetail'));
 const ChannelDetail = lazy(() => import('./components/routes/ChannelDetail'));
 const SearchFeed = lazy(() => import('./components/routes/SearchFeed'));
+
+const AnimatedRoutes = () => {
+  const location = useLocation();
+
+  return (
+    <AnimatePresence mode="wait">
+      <Routes location={location} key={location.pathname}>
+        <Route
+          path="/"
+          exact
+          element={
+            <AnimatedPage>
+              <Feed />
+            </AnimatedPage>
+          }
+        />
+        <Route
+          path="/video/:id"
+          element={
+            <AnimatedPage>
+              <VideoDetail />
+            </AnimatedPage>
+          }
+        />
+        <Route
+          path="/channel/:id"
+          element={
+            <AnimatedPage>
+              <ChannelDetail />
+            </AnimatedPage>
+          }
+        />
+        <Route
+          path="/search/:searchTerm"
+          element={
+            <AnimatedPage>
+              <SearchFeed />
+            </AnimatedPage>
+          }
+        />
+      </Routes>
+    </AnimatePresence>
+  );
+};
 
 const App = () => (
   <BrowserRouter>
@@ -18,12 +68,7 @@ const App = () => (
         <AppErrorBoundary>
           <Navbar />
           <Suspense fallback={<LoadingState message="Loading page..." />}>
-            <Routes>
-              <Route path="/" exact element={<Feed />} />
-              <Route path="/video/:id" element={<VideoDetail />} />
-              <Route path="/channel/:id" element={<ChannelDetail />} />
-              <Route path="/search/:searchTerm" element={<SearchFeed />} />
-            </Routes>
+            <AnimatedRoutes />
           </Suspense>
         </AppErrorBoundary>
       </Box>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -8,6 +8,7 @@ export { default as LoadingState } from './shared/LoadingState';
 export { default as ErrorState } from './shared/ErrorState';
 export { default as EmptyState } from './shared/EmptyState';
 export { default as AppErrorBoundary } from './shared/AppErrorBoundary';
+export { default as AnimatedPage } from './shared/AnimatedPage';
 export { default as Sidebar } from './shared/Sidebar';
 export { default as VideoGridSkeleton } from './shared/VideoCardSkeleton';
 export { default as Videos } from './video/Videos';

--- a/src/components/shared/AnimatedPage.jsx
+++ b/src/components/shared/AnimatedPage.jsx
@@ -1,0 +1,21 @@
+import { motion } from 'framer-motion';
+
+const animations = {
+  initial: { opacity: 0, y: 20 },
+  animate: { opacity: 1, y: 0 },
+  exit: { opacity: 0, y: -20 },
+};
+
+const AnimatedPage = ({ children }) => (
+  <motion.div
+    initial="initial"
+    animate="animate"
+    exit="exit"
+    variants={animations}
+    transition={{ duration: 0.3, ease: 'easeOut' }}
+  >
+    {children}
+  </motion.div>
+);
+
+export default AnimatedPage;


### PR DESCRIPTION
## Summary

Adds smooth fade + slide-up transitions between route navigations using Framer Motion, completing Phase 1 (Visual Identity).

## Changes

### Install: `framer-motion` ^12.41.0

### New: `src/components/shared/AnimatedPage.jsx`
- Wraps children in `motion.div` with:
  - **Fade**: opacity 0 → 1
  - **Slide**: translateY(20px) → 0
  - **Duration**: 0.3s ease-out
  - **Exit**: reverse (fade out + slide up)

### Updated: `App.jsx`
- Extracted `<Routes>` into `AnimatedRoutes` component that uses `useLocation()`
- Wrapped `<Routes>` with `<AnimatePresence mode=wait>`
- Passed `location` + `key={location.pathname}` to Routes for proper re-animation on nav
- All 4 route elements wrapped with `<AnimatedPage>`

