### PR TITLE
Phase 2.1: Infinite Scroll — load more videos on scroll

### DIFF
--- a/src/components/routes/Feed.jsx
+++ b/src/components/routes/Feed.jsx
@@ -1,23 +1,28 @@
 import { useCallback, useState } from 'react';
-import { Box, Stack, Typography } from '@mui/material';
+import { Box, CircularProgress, Stack, Typography } from '@mui/material';
 import { fetchSearchVideos } from '../../utils/fetchFromAPI';
-import { useAsyncResource } from '../../hooks';
+import { useInfiniteScroll } from '../../hooks';
 import { Sidebar, ErrorState, Videos, VideoGridSkeleton } from '../';
 
 const Feed = () => {
   const [selectedCategory, setSelectedCategory] = useState('New');
-  const loadVideos = useCallback(() => {
-    return fetchSearchVideos(selectedCategory);
-  }, [selectedCategory]);
+  const loadVideos = useCallback(
+    (pageToken) => {
+      return fetchSearchVideos(selectedCategory, pageToken);
+    },
+    [selectedCategory]
+  );
 
   const {
-    data: videos,
+    items: videos,
     isLoading,
+    isLoadingMore,
     errorMessage,
+    hasMore,
+    sentinelRef,
     reload,
-  } = useAsyncResource({
+  } = useInfiniteScroll({
     loader: loadVideos,
-    initialData: [],
     fallbackErrorMessage: 'Unable to load videos.',
   });
 
@@ -69,7 +74,15 @@ const Feed = () => {
             onRetry={reload}
           />
         ) : (
-          <Videos videos={videos} />
+          <>
+            <Videos videos={videos} />
+            {isLoadingMore && (
+              <Box display="flex" justifyContent="center" py={3}>
+                <CircularProgress size={28} sx={{ color: 'primary.main' }} />
+              </Box>
+            )}
+            {hasMore && <div ref={sentinelRef} style={{ height: 1 }} />}
+          </>
         )}
       </Box>
     </Stack>

--- a/src/components/routes/SearchFeed.jsx
+++ b/src/components/routes/SearchFeed.jsx
@@ -1,24 +1,29 @@
 import { useCallback } from 'react';
 import { useParams } from 'react-router-dom';
-import { Box, Typography } from '@mui/material';
+import { Box, CircularProgress, Typography } from '@mui/material';
 import { fetchSearchVideos } from '../../utils/fetchFromAPI';
-import { useAsyncResource } from '../../hooks';
+import { useInfiniteScroll } from '../../hooks';
 import { Videos, ErrorState, VideoGridSkeleton } from '../';
 
 const SearchFeed = () => {
   const { searchTerm } = useParams();
-  const loadVideos = useCallback(() => {
-    return fetchSearchVideos(searchTerm);
-  }, [searchTerm]);
+  const loadVideos = useCallback(
+    (pageToken) => {
+      return fetchSearchVideos(searchTerm, pageToken);
+    },
+    [searchTerm]
+  );
 
   const {
-    data: videos,
+    items: videos,
     isLoading,
+    isLoadingMore,
     errorMessage,
+    hasMore,
+    sentinelRef,
     reload,
-  } = useAsyncResource({
+  } = useInfiniteScroll({
     loader: loadVideos,
-    initialData: [],
     fallbackErrorMessage: 'Search failed.',
   });
 
@@ -51,7 +56,15 @@ const SearchFeed = () => {
           onRetry={reload}
         />
       ) : (
-        <Videos videos={videos} />
+        <>
+          <Videos videos={videos} />
+          {isLoadingMore && (
+            <Box display="flex" justifyContent="center" py={3}>
+              <CircularProgress size={28} sx={{ color: 'primary.main' }} />
+            </Box>
+          )}
+          {hasMore && <div ref={sentinelRef} style={{ height: 1 }} />}
+        </>
       )}
     </Box>
   );

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -1,1 +1,2 @@
 export { useAsyncResource } from './useAsyncResource';
+export { useInfiniteScroll } from './useInfiniteScroll';

--- a/src/hooks/useInfiniteScroll.js
+++ b/src/hooks/useInfiniteScroll.js
@@ -1,0 +1,111 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const getErrorMessage = (error, fallbackMessage) => {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+  return fallbackMessage;
+};
+
+export const useInfiniteScroll = ({
+  loader,
+  fallbackErrorMessage = 'Unable to load data.',
+}) => {
+  const [items, setItems] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [nextPageToken, setNextPageToken] = useState(null);
+  const [reloadToken, setReloadToken] = useState(0);
+
+  const sentinelRef = useRef(null);
+  const isLoadingMoreRef = useRef(false);
+  const loaderRef = useRef(loader);
+
+  if (loader !== loaderRef.current) {
+    loaderRef.current = loader;
+    setItems([]);
+    setNextPageToken(null);
+  }
+
+  const loadInitial = useCallback(async () => {
+    setIsLoading(true);
+    setErrorMessage('');
+
+    try {
+      const result = await loader(null);
+      setItems(result.items);
+      setNextPageToken(result.nextPageToken);
+    } catch (error) {
+      setItems([]);
+      setNextPageToken(null);
+      setErrorMessage(getErrorMessage(error, fallbackErrorMessage));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [loader, fallbackErrorMessage]);
+
+  const loadMore = useCallback(async () => {
+    if (isLoadingMoreRef.current || !nextPageToken) {
+      return;
+    }
+
+    isLoadingMoreRef.current = true;
+    setIsLoadingMore(true);
+
+    try {
+      const result = await loader(nextPageToken);
+      setItems((prev) => [...prev, ...result.items]);
+      setNextPageToken(result.nextPageToken);
+    } catch (error) {
+      setErrorMessage(getErrorMessage(error, fallbackErrorMessage));
+    } finally {
+      setIsLoadingMore(false);
+      isLoadingMoreRef.current = false;
+    }
+  }, [loader, nextPageToken, fallbackErrorMessage]);
+
+  useEffect(() => {
+    loadInitial();
+  }, [loadInitial, reloadToken]);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (
+          entries[0].isIntersecting &&
+          nextPageToken &&
+          !isLoadingMoreRef.current
+        ) {
+          loadMore();
+        }
+      },
+      { rootMargin: '200px' }
+    );
+
+    observer.observe(sentinel);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [nextPageToken, loadMore]);
+
+  return {
+    items,
+    isLoading,
+    isLoadingMore,
+    errorMessage,
+    hasMore: !!nextPageToken,
+    sentinelRef,
+    reload: () => {
+      setReloadToken((current) => current + 1);
+      setItems([]);
+      setNextPageToken(null);
+    },
+  };
+};

--- a/src/utils/fetchFromAPI.js
+++ b/src/utils/fetchFromAPI.js
@@ -13,7 +13,7 @@ export class ApiError extends Error {
   }
 }
 
-const getRequestOptions = () => {
+const getRequestOptions = (pageToken) => {
   const apiKey = process.env.REACT_APP_RAPID_API_KEY;
 
   if (!apiKey) {
@@ -25,6 +25,7 @@ const getRequestOptions = () => {
   return {
     params: {
       maxResults: '50',
+      ...(pageToken ? { pageToken } : {}),
     },
     headers: {
       'x-rapidapi-key': apiKey,
@@ -98,18 +99,21 @@ const mapApiError = (error) => {
   });
 };
 
-export const fetchFromAPI = async (url) => {
+export const fetchFromAPI = async (url, pageToken) => {
   try {
-    const { data } = await axios.get(`${BASE_URL}/${url}`, getRequestOptions());
+    const { data } = await axios.get(
+      `${BASE_URL}/${url}`,
+      getRequestOptions(pageToken)
+    );
     return ensureApiResponse(data);
   } catch (error) {
     throw mapApiError(error);
   }
 };
 
-export const fetchSearchVideos = async (query) => {
-  const data = await fetchFromAPI(`search?part=snippet&q=${query}`);
-  return data.items ?? [];
+export const fetchSearchVideos = async (query, pageToken) => {
+  const data = await fetchFromAPI(`search?part=snippet&q=${query}`, pageToken);
+  return { items: data.items ?? [], nextPageToken: data.nextPageToken ?? null };
 };
 
 export const fetchVideoDetails = async (id) => {


### PR DESCRIPTION
## Summary

Adds infinite scroll pagination to Feed and SearchFeed. When the user scrolls to the bottom, the next page of 50 results is fetched and appended via the YouTube API's `nextPageToken`.

## Changes

### API client (`fetchFromAPI.js`)
- `fetchFromAPI` now accepts optional `pageToken` parameter, passed as request param
- `fetchSearchVideos` returns `{ items, nextPageToken }` instead of raw items array

### New: `src/hooks/useInfiniteScroll.js`
- **IntersectionObserver** on a sentinel element with 200px rootMargin
- Accumulates items across pages
- Separate `isLoading` (initial) vs `isLoadingMore` (subsequent pages)
- Tracks `loader` ref; resets state automatically when loader changes (category/search switch)
- Exposes `hasMore`, `sentinelRef`, `reload`

### Updated: `Feed.jsx` and `SearchFeed.jsx`
- Replaced `useAsyncResource` with `useInfiniteScroll`
- Bottom spinner (`CircularProgress`) while loading more
- Invisible sentinel div triggers next page load

