### PR TITLE
Phase 2.3: Top Loading Bar for route transitions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import {
   LoadingState,
   AnimatedPage,
 } from './components/';
+import { LoadingBarProvider } from './components/layout/TopLoadingBar';
 import { theme } from './themes/';
 
 const Feed = lazy(() => import('./components/routes/Feed'));
@@ -67,9 +68,11 @@ const App = () => (
       <Box sx={{ backgroundColor: 'background.default' }}>
         <AppErrorBoundary>
           <Navbar />
-          <Suspense fallback={<LoadingState message="Loading page..." />}>
-            <AnimatedRoutes />
-          </Suspense>
+          <LoadingBarProvider>
+            <Suspense fallback={<LoadingState message="Loading page..." />}>
+              <AnimatedRoutes />
+            </Suspense>
+          </LoadingBarProvider>
         </AppErrorBoundary>
       </Box>
     </ThemeProvider>

--- a/src/components/layout/TopLoadingBar.jsx
+++ b/src/components/layout/TopLoadingBar.jsx
@@ -1,0 +1,94 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { motion } from 'framer-motion';
+import { useLocation } from 'react-router-dom';
+import { useTheme } from '@mui/material';
+
+const LoadingBarContext = createContext(null);
+
+export const useLoadingBar = () => {
+  const ctx = useContext(LoadingBarContext);
+  return ctx ?? { start() {}, done() {} };
+};
+
+export const LoadingBarProvider = ({ children }) => {
+  const [progress, setProgress] = useState(0);
+  const [visible, setVisible] = useState(false);
+  const timerRef = useRef(null);
+  const hasCompleted = useRef(false);
+  const location = useLocation();
+  const prevPath = useRef(location.pathname);
+
+  const clearTimer = () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  };
+
+  const done = useCallback(() => {
+    hasCompleted.current = true;
+    clearTimer();
+    setProgress(100);
+    timerRef.current = setTimeout(() => {
+      setVisible(false);
+      setProgress(0);
+    }, 400);
+  }, []);
+
+  const start = useCallback(() => {
+    hasCompleted.current = false;
+    clearTimer();
+    setProgress(0);
+    setVisible(true);
+    requestAnimationFrame(() => {
+      if (!hasCompleted.current) {
+        setProgress(30);
+      }
+    });
+    timerRef.current = setTimeout(() => {
+      if (!hasCompleted.current) {
+        setProgress(70);
+      }
+    }, 400);
+  }, []);
+
+  useEffect(() => {
+    if (prevPath.current !== location.pathname) {
+      prevPath.current = location.pathname;
+      start();
+      timerRef.current = setTimeout(done, 3000);
+    }
+    return clearTimer;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location.pathname]);
+
+  const theme = useTheme();
+  const barColor = theme.palette.primary.main;
+
+  return (
+    <LoadingBarContext.Provider value={{ start, done }}>
+      {visible && (
+        <motion.div
+          style={{
+            position: 'fixed',
+            top: 0,
+            left: 0,
+            height: 3,
+            backgroundColor: barColor,
+            zIndex: 9999,
+          }}
+          animate={{ width: `${progress}%` }}
+          transition={{ duration: 0.25, ease: 'easeOut' }}
+        />
+      )}
+      {children}
+    </LoadingBarContext.Provider>
+  );
+};

--- a/src/components/shared/AnimatedPage.jsx
+++ b/src/components/shared/AnimatedPage.jsx
@@ -1,4 +1,6 @@
+import { useEffect } from 'react';
 import { motion } from 'framer-motion';
+import { useLoadingBar } from '../layout/TopLoadingBar';
 
 const animations = {
   initial: { opacity: 0, y: 20 },
@@ -6,16 +8,24 @@ const animations = {
   exit: { opacity: 0, y: -20 },
 };
 
-const AnimatedPage = ({ children }) => (
-  <motion.div
-    initial="initial"
-    animate="animate"
-    exit="exit"
-    variants={animations}
-    transition={{ duration: 0.3, ease: 'easeOut' }}
-  >
-    {children}
-  </motion.div>
-);
+const AnimatedPage = ({ children }) => {
+  const { done } = useLoadingBar();
+
+  useEffect(() => {
+    done();
+  }, [done]);
+
+  return (
+    <motion.div
+      initial="initial"
+      animate="animate"
+      exit="exit"
+      variants={animations}
+      transition={{ duration: 0.3, ease: 'easeOut' }}
+    >
+      {children}
+    </motion.div>
+  );
+};
 
 export default AnimatedPage;


### PR DESCRIPTION
## Summary

Adds a top-of-page progress bar that animates during route transitions, giving visual feedback while lazy-loaded route chunks and data load.

## How it works

- **`LoadingBarProvider`** (`src/components/layout/TopLoadingBar.jsx`): Context provider that renders the bar and exposes `start()` / `done()` via `useLoadingBar()`. Automatically triggers `start()` on `location.pathname` changes (bumps to 30% instantly, 70% after 400ms). Falls back to auto-`done()` at 3s.
- **`AnimatedPage`** (`src/components/shared/AnimatedPage.jsx`): Now calls `done()` in a `useEffect` on mount, completing the bar to 100% when the lazy chunk has loaded and the new route renders.
- **`App.jsx`**: Wraps routes with `LoadingBarProvider`.

## Behavior
- Bar (3px, primary red) slides in from left on every navigation
- Rapidly fills to ~30%, then more slowly to ~70%
- Completes to 100% when the new route's `AnimatedPage` mounts
- Fades out 400ms after completion
- 3-second auto-fallback if `done()` never fires

