### PR TITLE
Phase 4 – Performance improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,10 +17,6 @@
       rel="stylesheet"
       href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap"
     />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/icon?family=Material+Icons"
-    />
 
     <title>youtube_clone</title>
   </head>

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,9 +1,4 @@
 export { default as Navbar } from './layout/Navbar';
-export { default as SearchBar } from './layout/SearchBar';
-export { default as Feed } from './routes/Feed';
-export { default as ChannelDetail } from './routes/ChannelDetail';
-export { default as SearchFeed } from './routes/SearchFeed';
-export { default as VideoDetail } from './routes/VideoDetail';
 export { default as LoadingState } from './shared/LoadingState';
 export { default as ErrorState } from './shared/ErrorState';
 export { default as EmptyState } from './shared/EmptyState';
@@ -13,8 +8,4 @@ export { default as Sidebar } from './shared/Sidebar';
 export { default as CategoryChips } from './shared/CategoryChips';
 export { default as VideoGridSkeleton } from './shared/VideoCardSkeleton';
 export { default as Videos } from './video/Videos';
-export { default as VideoCard } from './video/VideoCard';
 export { default as ChannelCard } from './video/ChannelCard';
-export { default as Shorts } from './routes/Shorts';
-export { default as Subscriptions } from './routes/Subscriptions';
-export { default as You } from './routes/You';

--- a/src/components/shared/CategoryChips.jsx
+++ b/src/components/shared/CategoryChips.jsx
@@ -1,7 +1,8 @@
+import { memo } from 'react';
 import { Chip, Stack, useMediaQuery, useTheme } from '@mui/material';
 import { categories } from '../../utils/constants';
 
-const CategoryChips = ({ selectedCategory, setSelectedCategory }) => {
+const CategoryChips = memo(({ selectedCategory, setSelectedCategory }) => {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
 
@@ -49,6 +50,6 @@ const CategoryChips = ({ selectedCategory, setSelectedCategory }) => {
       ))}
     </Stack>
   );
-};
+});
 
 export default CategoryChips;

--- a/src/components/shared/Sidebar.jsx
+++ b/src/components/shared/Sidebar.jsx
@@ -1,7 +1,8 @@
+import { memo } from 'react';
 import { Stack } from '@mui/material';
 import { categories } from '../../utils/constants';
 
-const Sidebar = ({ selectedCategory, setSelectedCategory }) => (
+const Sidebar = memo(({ selectedCategory, setSelectedCategory }) => (
   <Stack
     component="nav"
     aria-label="Video categories"
@@ -39,6 +40,6 @@ const Sidebar = ({ selectedCategory, setSelectedCategory }) => (
       </button>
     ))}
   </Stack>
-);
+));
 
 export default Sidebar;

--- a/src/components/video/VideoCard.jsx
+++ b/src/components/video/VideoCard.jsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { Link } from 'react-router-dom';
 
 import {
@@ -18,122 +19,124 @@ import {
   demoChannelTitle,
 } from '../../utils/constants';
 
-const VideoCard = ({
-  video: {
-    id: { videoId },
-    snippet,
-  },
-}) => {
-  const title = snippet?.title || demoVideoTitle;
-  const channelTitle = snippet?.channelTitle || demoChannelTitle;
-  const channelId = snippet?.channelId;
+const VideoCard = memo(
+  ({
+    video: {
+      id: { videoId },
+      snippet,
+    },
+  }) => {
+    const title = snippet?.title || demoVideoTitle;
+    const channelTitle = snippet?.channelTitle || demoChannelTitle;
+    const channelId = snippet?.channelId;
 
-  return (
-    <Card
-      sx={{
-        width: { xs: '100%', sm: '358px', md: '320px' },
-        boxShadow: 'none',
-        borderRadius: 0,
-        transition: 'transform 0.3s ease, box-shadow 0.3s ease',
-        '&:hover': {
-          transform: 'translateY(-4px)',
-          boxShadow: '0 8px 24px rgba(0,0,0,0.4)',
-        },
-      }}
-    >
-      <Link
-        to={videoId ? `/video/${videoId}` : demoVideoUrl}
-        aria-label={`Open video ${title}`}
-      >
-        <CardMedia
-          image={snippet?.thumbnails?.high?.url}
-          alt={snippet?.title}
-          sx={{
-            width: { xs: '100%', sm: '358px' },
-            height: 180,
-            transition: 'transform 0.3s ease',
-            '&:hover': {
-              transform: 'scale(1.05)',
-            },
-          }}
-        />
-      </Link>
-      <CardContent
+    return (
+      <Card
         sx={{
-          bgcolor: 'background.paper',
-          height: 'auto',
-          minHeight: 100,
-          p: 1.5,
-          display: 'flex',
-          gap: 1.5,
+          width: { xs: '100%', sm: '358px', md: '320px' },
+          boxShadow: 'none',
+          borderRadius: 0,
+          transition: 'transform 0.3s ease, box-shadow 0.3s ease',
+          '&:hover': {
+            transform: 'translateY(-4px)',
+            boxShadow: '0 8px 24px rgba(0,0,0,0.4)',
+          },
         }}
       >
         <Link
-          to={channelId ? `/channel/${channelId}` : demoChannelUrl}
-          aria-label={`Open channel ${channelTitle}`}
-          sx={{ flexShrink: 0, height: 'fit-content' }}
+          to={videoId ? `/video/${videoId}` : demoVideoUrl}
+          aria-label={`Open video ${title}`}
         >
-          <Avatar
-            alt={channelTitle}
+          <CardMedia
+            image={snippet?.thumbnails?.high?.url}
+            alt={snippet?.title}
             sx={{
-              width: 36,
-              height: 36,
-              bgcolor: 'primary.main',
-              fontSize: 16,
+              width: { xs: '100%', sm: '358px' },
+              height: 180,
+              transition: 'transform 0.3s ease',
+              '&:hover': {
+                transform: 'scale(1.05)',
+              },
             }}
-          >
-            {channelTitle.charAt(0).toUpperCase()}
-          </Avatar>
+          />
         </Link>
-        <Box sx={{ minWidth: 0, flex: 1 }}>
-          <Link
-            to={videoId ? `/video/${videoId}` : demoVideoUrl}
-            aria-label={`Open video ${title}`}
-          >
-            <Typography
-              variant="subtitle2"
-              fontWeight="bold"
-              color="text.primary"
-              sx={{
-                display: '-webkit-box',
-                WebkitLineClamp: 2,
-                WebkitBoxOrient: 'vertical',
-                overflow: 'hidden',
-                lineHeight: 1.3,
-                mb: 0.5,
-              }}
-            >
-              {title}
-            </Typography>
-          </Link>
+        <CardContent
+          sx={{
+            bgcolor: 'background.paper',
+            height: 'auto',
+            minHeight: 100,
+            p: 1.5,
+            display: 'flex',
+            gap: 1.5,
+          }}
+        >
           <Link
             to={channelId ? `/channel/${channelId}` : demoChannelUrl}
             aria-label={`Open channel ${channelTitle}`}
-            sx={{ display: 'inline-flex', alignItems: 'center' }}
+            sx={{ flexShrink: 0, height: 'fit-content' }}
           >
-            <Typography
-              variant="caption"
-              color="text.secondary"
-              sx={{ mr: 0.5 }}
+            <Avatar
+              alt={channelTitle}
+              sx={{
+                width: 36,
+                height: 36,
+                bgcolor: 'primary.main',
+                fontSize: 16,
+              }}
             >
-              {channelTitle}
-            </Typography>
-            <CheckCircle
-              aria-hidden="true"
-              sx={{ fontSize: 12, color: 'custom.verifiedBadge' }}
-            />
+              {channelTitle.charAt(0).toUpperCase()}
+            </Avatar>
           </Link>
-          <Box>
-            {snippet?.publishedAt && (
-              <Typography variant="caption" color="text.secondary">
-                {formatRelativeTime(snippet.publishedAt)}
+          <Box sx={{ minWidth: 0, flex: 1 }}>
+            <Link
+              to={videoId ? `/video/${videoId}` : demoVideoUrl}
+              aria-label={`Open video ${title}`}
+            >
+              <Typography
+                variant="subtitle2"
+                fontWeight="bold"
+                color="text.primary"
+                sx={{
+                  display: '-webkit-box',
+                  WebkitLineClamp: 2,
+                  WebkitBoxOrient: 'vertical',
+                  overflow: 'hidden',
+                  lineHeight: 1.3,
+                  mb: 0.5,
+                }}
+              >
+                {title}
               </Typography>
-            )}
+            </Link>
+            <Link
+              to={channelId ? `/channel/${channelId}` : demoChannelUrl}
+              aria-label={`Open channel ${channelTitle}`}
+              sx={{ display: 'inline-flex', alignItems: 'center' }}
+            >
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ mr: 0.5 }}
+              >
+                {channelTitle}
+              </Typography>
+              <CheckCircle
+                aria-hidden="true"
+                sx={{ fontSize: 12, color: 'custom.verifiedBadge' }}
+              />
+            </Link>
+            <Box>
+              {snippet?.publishedAt && (
+                <Typography variant="caption" color="text.secondary">
+                  {formatRelativeTime(snippet.publishedAt)}
+                </Typography>
+              )}
+            </Box>
           </Box>
-        </Box>
-      </CardContent>
-    </Card>
-  );
-};
+        </CardContent>
+      </Card>
+    );
+  }
+);
 
 export default VideoCard;

--- a/src/components/video/Videos.jsx
+++ b/src/components/video/Videos.jsx
@@ -20,8 +20,8 @@ const Videos = ({ videos, direction }) => {
       justifyContent="start"
       gap={2}
     >
-      {videos.map((item, idx) => (
-        <Box key={idx}>
+      {videos.map((item) => (
+        <Box key={item.id.videoId || item.id.channelId}>
           {item.id.videoId && <VideoCard video={item} />}
           {item.id.channelId && <ChannelCard channelDetail={item} />}
         </Box>


### PR DESCRIPTION
### Changes

- **Code splitting**: Removed route re-exports from components/index.js barrel file — routes (Feed, VideoDetail, ChannelDetail, SearchFeed, Shorts, Subscriptions, You) were statically re-exported, forcing webpack to bundle them eagerly and defeating React.lazy(). Now each route is only loaded via dynamic import.

- **React.memo**: Wrapped VideoCard, CategoryChips, and Sidebar with React.memo to prevent unnecessary re-renders when parent state changes but props haven't.

- **List keys**: Replaced array index keys in Videos.jsx with stable videoId/channelId keys for proper reconciliation.

- **Removed unused font**: Removed Material Icons font stylesheet from index.html — the project uses @mui/icons-material SVG components, not the font.