### PR TITLE
Phase 5 – Redesigned channel detail page

### DIFF
--- a/src/components/routes/ChannelDetail.jsx
+++ b/src/components/routes/ChannelDetail.jsx
@@ -1,13 +1,23 @@
 import { useCallback, useState } from 'react';
 import { useParams } from 'react-router-dom';
-import { Box, Button } from '@mui/material';
-import { Videos, ChannelCard, LoadingState, ErrorState } from '../';
+import { Avatar, Box, Button, Chip, Stack, Typography } from '@mui/material';
+import { CheckCircle } from '@mui/icons-material';
+import { Videos, LoadingState, ErrorState } from '../';
 import { useAsyncResource } from '../../hooks';
 import {
   fetchChannelDetails,
   fetchChannelVideos,
 } from '../../utils/fetchFromAPI';
 import { isSubscribed, toggleSubscription } from '../../utils/subscriptions';
+import { demoProfilePicture } from '../../utils/constants';
+
+const abbreviateNumber = (num) => {
+  if (!num) {return null;}
+  const n = parseInt(num, 10);
+  if (n >= 1000000) {return (n / 1000000).toFixed(1).replace(/\.0$/, '') + 'M';}
+  if (n >= 1000) {return (n / 1000).toFixed(1).replace(/\.0$/, '') + 'K';}
+  return n.toLocaleString();
+};
 
 const ChannelDetail = () => {
   const { id } = useParams();
@@ -41,6 +51,7 @@ const ChannelDetail = () => {
   const channelId = channelDetail?.id?.channelId || channelDetail?.id;
   const [, setSubTick] = useState(0);
   const subscribed = isSubscribed(channelId);
+  const bannerUrl = channelDetail?.brandingSettings?.image?.bannerExternalUrl;
 
   const handleSubscribe = () => {
     toggleSubscription({
@@ -75,32 +86,100 @@ const ChannelDetail = () => {
     );
   }
 
+  const snippet = channelDetail.snippet;
+  const stats = channelDetail.statistics;
+
   return (
     <Box component="main" minHeight="95vh">
-      <Box>
-        <div
-          style={{
-            background:
-              'linear-Gradient(90deg,rgba(0,238,247,1)0%,rgba(206,3,184,1)100%,rgba(0,212,255,1)100%)',
-            zIndex: 10,
-            height: '300px',
+      <Box
+        sx={{
+          height: { xs: 150, sm: 200, md: 250 },
+          background: bannerUrl
+            ? `url(${bannerUrl}) center/cover no-repeat`
+            : 'linear-gradient(135deg, #0ea5e9 0%, #7c3aed 50%, #ec4899 100%)',
+        }}
+      />
+      <Stack
+        direction={{ xs: 'column', sm: 'row' }}
+        spacing={2}
+        alignItems={{ xs: 'center', sm: 'flex-start' }}
+        sx={{ px: { xs: 2, md: 4 }, mt: { xs: -4, sm: -6 }, mb: 3 }}
+      >
+        <Avatar
+          src={snippet?.thumbnails?.high?.url || demoProfilePicture}
+          alt={snippet?.title}
+          sx={{
+            width: { xs: 72, sm: 96, md: 120 },
+            height: { xs: 72, sm: 96, md: 120 },
+            border: '3px solid',
+            borderColor: 'background.default',
+            bgcolor: 'primary.main',
           }}
-        ></div>
-        <ChannelCard channelDetail={channelDetail} marginTop="-110px" />
-      </Box>
-      <Box display="flex" justifyContent="center" mt={-2} mb={2}>
-        <Button
-          variant={subscribed ? 'outlined' : 'contained'}
-          color="primary"
-          size="medium"
-          onClick={handleSubscribe}
-          sx={{ textTransform: 'none', borderRadius: 20, px: 3 }}
-        >
-          {subscribed ? 'Subscribed' : 'Subscribe'}
-        </Button>
-      </Box>
-      <Box display="flex" p="2">
-        <Box sx={{ mr: { sm: '100px' } }} />
+        />
+        <Box sx={{ flex: 1, textAlign: { xs: 'center', sm: 'left' } }}>
+          <Typography variant="h5" fontWeight="bold" color="text.primary">
+            {snippet?.title}
+            <CheckCircle
+              aria-hidden="true"
+              sx={{
+                fontSize: 18,
+                color: 'custom.verifiedBadge',
+                ml: 0.5,
+                verticalAlign: 'middle',
+              }}
+            />
+          </Typography>
+          <Stack
+            direction="row"
+            spacing={1}
+            flexWrap="wrap"
+            justifyContent={{ xs: 'center', sm: 'flex-start' }}
+            sx={{ mt: 0.5, mb: 1 }}
+          >
+            <Typography variant="body2" color="text.secondary">
+              {snippet?.customUrl || `@${snippet?.title?.replace(/\s+/g, '')}`}
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {abbreviateNumber(stats?.subscriberCount)} subscribers
+            </Typography>
+            <Typography variant="body2" color="text.secondary">
+              {abbreviateNumber(stats?.videoCount)} videos
+            </Typography>
+          </Stack>
+          {snippet?.description && (
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{
+                mb: 1.5,
+                display: '-webkit-box',
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: 'vertical',
+                overflow: 'hidden',
+              }}
+            >
+              {snippet.description}
+            </Typography>
+          )}
+          <Stack
+            direction="row"
+            spacing={1}
+            justifyContent={{ xs: 'center', sm: 'flex-start' }}
+          >
+            <Button
+              variant={subscribed ? 'outlined' : 'contained'}
+              color="primary"
+              size="medium"
+              onClick={handleSubscribe}
+              sx={{ textTransform: 'none', borderRadius: 20, px: 3 }}
+            >
+              {subscribed ? 'Subscribed' : 'Subscribe'}
+            </Button>
+            <Chip label="Videos" color="primary" size="small" />
+          </Stack>
+        </Box>
+      </Stack>
+      <Box sx={{ px: { xs: 2, md: 4 }, pb: { xs: 7, md: 2 } }}>
         <Videos videos={videos} />
       </Box>
     </Box>

--- a/src/utils/fetchFromAPI.js
+++ b/src/utils/fetchFromAPI.js
@@ -129,7 +129,9 @@ export const fetchRelatedVideos = async (id) => {
 };
 
 export const fetchChannelDetails = async (id) => {
-  const data = await fetchFromAPI(`channels?part=snippet,statistics&id=${id}`);
+  const data = await fetchFromAPI(
+    `channels?part=snippet,statistics,brandingSettings&id=${id}`
+  );
   return data.items?.[0] ?? null;
 };
 


### PR DESCRIPTION
### Changes

- **Channel banner**: Now uses the channel's actual banner image from the API (fetched via `brandingSettings` part). Falls back to a gradient if unavailable.

- **Channel info section**: Clean YouTube-like layout with avatar, channel name (with verified badge), custom URL, subscriber count, video count, and description — stacked vertically on mobile, side-by-side on desktop.

- **Subscribe button**: Moved inline with channel info instead of floating separately below.

- **Videos grid**: Properly padded and displayed below the channel info section.

- **Removed `ChannelCard` import**: The channel detail page now renders info inline instead of reusing the card component, giving more layout control.

Closes #73