### PR TITLE
Phase 5 – YouTube-style subscription cards

### DIFF
--- a/src/components/routes/Subscriptions.jsx
+++ b/src/components/routes/Subscriptions.jsx
@@ -1,9 +1,9 @@
-import { useCallback, useEffect, useState } from 'react';
-import { Avatar, Box, Button, Typography } from '@mui/material';
-import { Link } from 'react-router-dom';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Box, Stack, Typography } from '@mui/material';
 import { fetchChannelVideos } from '../../utils/fetchFromAPI';
 import { getSubscriptions } from '../../utils/subscriptions';
 import { Videos, EmptyState, ErrorState, VideoGridSkeleton } from '../';
+import SubscriptionCard from '../shared/SubscriptionCard';
 
 const Subscriptions = () => {
   const [videos, setVideos] = useState([]);
@@ -43,7 +43,7 @@ const Subscriptions = () => {
     loadSubVideos();
   }, [loadSubVideos]);
 
-  const subs = getSubscriptions();
+  const subs = useMemo(() => getSubscriptions(), []);
 
   if (subs.length === 0) {
     return (
@@ -80,29 +80,31 @@ const Subscriptions = () => {
       >
         Subscriptions
       </Typography>
-      <Box display="flex" gap={1.5} flexWrap="wrap" mb={3}>
+      <Stack
+        direction="row"
+        spacing={0.5}
+        sx={{
+          overflow: 'auto',
+          mb: 3,
+          '&::-webkit-scrollbar': { display: 'none' },
+          scrollbarWidth: 'none',
+        }}
+      >
         {subs.map((sub) => (
-          <Button
+          <Box
             key={sub.id}
-            component={Link}
-            to={`/channel/${sub.id}`}
-            variant="outlined"
-            size="small"
-            startIcon={
-              <Avatar
-                src={sub.thumbnail}
-                alt={sub.title}
-                sx={{ width: 24, height: 24 }}
-              >
-                {sub.title?.charAt(0)}
-              </Avatar>
-            }
-            sx={{ textTransform: 'none', borderRadius: 20 }}
+            sx={{
+              minWidth: 200,
+              border: '1px solid',
+              borderColor: 'divider',
+              borderRadius: 2,
+              flexShrink: 0,
+            }}
           >
-            {sub.title}
-          </Button>
+            <SubscriptionCard sub={sub} />
+          </Box>
         ))}
-      </Box>
+      </Stack>
       {isLoading ? (
         <VideoGridSkeleton count={4} />
       ) : errorMessage ? (

--- a/src/components/routes/You.jsx
+++ b/src/components/routes/You.jsx
@@ -1,4 +1,5 @@
-import { Box, Chip, Divider, Typography } from '@mui/material';
+import { useMemo } from 'react';
+import { Box, Chip, Divider, Stack, Typography } from '@mui/material';
 import {
   History,
   Subscriptions as SubscriptionsIcon,
@@ -11,6 +12,7 @@ import {
   getSubscriptionCount,
 } from '../../utils/subscriptions';
 import { Videos } from '../';
+import SubscriptionCard from '../shared/SubscriptionCard';
 import { Link } from 'react-router-dom';
 
 const toVideoItem = (rw) => ({
@@ -24,9 +26,9 @@ const toVideoItem = (rw) => ({
 });
 
 const You = () => {
-  const recentlyWatched = getRecentlyWatched();
-  const subs = getSubscriptions();
-  const subCount = getSubscriptionCount();
+  const recentlyWatched = useMemo(() => getRecentlyWatched(), []);
+  const subs = useMemo(() => getSubscriptions(), []);
+  const subCount = useMemo(() => getSubscriptionCount(), []);
 
   return (
     <Box
@@ -83,27 +85,30 @@ const You = () => {
               Subscriptions
             </Typography>
           </Box>
-          <Box display="flex" gap={1} flexWrap="wrap">
+          <Stack
+            direction="row"
+            spacing={0.5}
+            sx={{
+              overflow: 'auto',
+              '&::-webkit-scrollbar': { display: 'none' },
+              scrollbarWidth: 'none',
+            }}
+          >
             {subs.map((sub) => (
-              <Chip
+              <Box
                 key={sub.id}
-                label={sub.title}
-                component={Link}
-                to={`/channel/${sub.id}`}
-                avatar={
-                  <Box
-                    component="img"
-                    src={sub.thumbnail}
-                    alt={sub.title}
-                    sx={{ width: 24, height: 24, borderRadius: '50%' }}
-                  />
-                }
-                variant="outlined"
-                clickable
-                sx={{ borderRadius: 20 }}
-              />
+                sx={{
+                  minWidth: 200,
+                  border: '1px solid',
+                  borderColor: 'divider',
+                  borderRadius: 2,
+                  flexShrink: 0,
+                }}
+              >
+                <SubscriptionCard sub={sub} />
+              </Box>
             ))}
-          </Box>
+          </Stack>
         </Box>
       )}
 

--- a/src/components/shared/SubscriptionCard.jsx
+++ b/src/components/shared/SubscriptionCard.jsx
@@ -1,0 +1,80 @@
+import { useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import { Avatar, Box, Typography } from '@mui/material';
+import { CheckCircle } from '@mui/icons-material';
+
+const formatSubDate = (dateStr) => {
+  if (!dateStr) {return null;}
+  const days = Math.floor(
+    (Date.now() - new Date(dateStr).getTime()) / (1000 * 60 * 60 * 24)
+  );
+  if (days === 0) {return 'Subscribed today';}
+  if (days === 1) {return 'Subscribed yesterday';}
+  if (days < 30) {return `Subscribed ${days} days ago`;}
+  const months = Math.floor(days / 30);
+  if (months === 1) {return 'Subscribed 1 month ago';}
+  return `Subscribed ${months} months ago`;
+};
+
+const SubscriptionCard = ({ sub }) => {
+  const timeAgo = useMemo(
+    () => formatSubDate(sub.subscribedAt),
+    [sub.subscribedAt]
+  );
+
+  return (
+    <Box
+      component={Link}
+      to={`/channel/${sub.id}`}
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 1.5,
+        p: 1.5,
+        borderRadius: 2,
+        textDecoration: 'none',
+        transition: 'background-color 0.2s',
+        '&:hover': { bgcolor: 'action.hover' },
+      }}
+    >
+      <Avatar
+        src={sub.thumbnail}
+        alt={sub.title}
+        sx={{ width: 48, height: 48 }}
+      >
+        {sub.title?.charAt(0)}
+      </Avatar>
+      <Box sx={{ minWidth: 0, flex: 1 }}>
+        <Typography
+          variant="subtitle2"
+          fontWeight="bold"
+          color="text.primary"
+          sx={{
+            display: '-webkit-box',
+            WebkitLineClamp: 1,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+          }}
+        >
+          {sub.title}
+          <CheckCircle
+            aria-hidden="true"
+            sx={{
+              fontSize: 14,
+              color: 'custom.verifiedBadge',
+              ml: 0.3,
+              verticalAlign: 'middle',
+            }}
+          />
+        </Typography>
+        {timeAgo && (
+          <Typography variant="caption" color="text.secondary">
+            {timeAgo}
+          </Typography>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+export default SubscriptionCard;


### PR DESCRIPTION
### Changes

- **SubscriptionCard component**: Reusable card with 48px avatar, channel name, verified badge, and subscription time ago.

- **Subscriptions page**: Replaced basic button list with a horizontal scrollable row of SubscriptionCards inside bordered containers.

- **You page**: Same treatment for the subscription section — chips replaced with cards.

- **useMemo**: Wrapped localStorage reads (getRecentlyWatched, getSubscriptions, getSubscriptionCount) in useMemo to avoid re-computation on every render.

Closes #74