### PR TITLE
Phase 8 – Watch later playlist

### DIFF
--- a/src/components/routes/You.jsx
+++ b/src/components/routes/You.jsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react';
 import { Box, Chip, Divider, Stack, Typography } from '@mui/material';
 import {
+  Bookmark,
   History,
   Subscriptions as SubscriptionsIcon,
   VideoLibrary,
@@ -11,6 +12,7 @@ import {
   getSubscriptions,
   getSubscriptionCount,
 } from '../../utils/subscriptions';
+import { getWatchLater, getWatchLaterCount } from '../../utils/watchLater';
 import { Videos } from '../';
 import SubscriptionCard from '../shared/SubscriptionCard';
 import { Link } from 'react-router-dom';
@@ -25,10 +27,22 @@ const toVideoItem = (rw) => ({
   },
 });
 
+const toWLVideoItem = (wl) => ({
+  id: { videoId: wl.id },
+  snippet: {
+    title: wl.title,
+    channelTitle: wl.channelTitle,
+    channelId: wl.channelId,
+    thumbnails: { high: { url: wl.thumbnail } },
+  },
+});
+
 const You = () => {
   const recentlyWatched = useMemo(() => getRecentlyWatched(), []);
   const subs = useMemo(() => getSubscriptions(), []);
   const subCount = useMemo(() => getSubscriptionCount(), []);
+  const watchLater = useMemo(() => getWatchLater(), []);
+  const wlCount = useMemo(() => getWatchLaterCount(), []);
 
   return (
     <Box
@@ -109,6 +123,21 @@ const You = () => {
               </Box>
             ))}
           </Stack>
+        </Box>
+      )}
+
+      {watchLater.length > 0 && (
+        <Box mb={3}>
+          <Typography
+            variant="h6"
+            fontWeight="bold"
+            mb={1}
+            sx={{ color: 'text.primary' }}
+          >
+            <Bookmark sx={{ fontSize: 20, verticalAlign: 'middle', mr: 0.5 }} />
+            Watch later ({wlCount})
+          </Typography>
+          <Videos videos={watchLater.map(toWLVideoItem)} />
         </Box>
       )}
 

--- a/src/components/video/VideoCard.jsx
+++ b/src/components/video/VideoCard.jsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import {
@@ -7,9 +7,10 @@ import {
   Card,
   CardContent,
   CardMedia,
+  IconButton,
   Typography,
 } from '@mui/material';
-import { CheckCircle } from '@mui/icons-material';
+import { Bookmark, BookmarkBorder, CheckCircle } from '@mui/icons-material';
 
 import { formatRelativeTime } from '../../utils/formatRelativeTime';
 import {
@@ -18,6 +19,7 @@ import {
   demoChannelUrl,
   demoChannelTitle,
 } from '../../utils/constants';
+import { isInWatchLater, toggleWatchLater } from '../../utils/watchLater';
 
 const VideoCard = memo(
   ({
@@ -26,9 +28,23 @@ const VideoCard = memo(
       snippet,
     },
   }) => {
+    const [saved, setSaved] = useState(isInWatchLater(videoId));
     const title = snippet?.title || demoVideoTitle;
     const channelTitle = snippet?.channelTitle || demoChannelTitle;
     const channelId = snippet?.channelId;
+
+    const handleToggle = (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      toggleWatchLater({
+        id: videoId,
+        title,
+        channelTitle,
+        channelId,
+        thumbnail: snippet?.thumbnails?.high?.url,
+      });
+      setSaved((s) => !s);
+    };
 
     return (
       <Card
@@ -43,23 +59,47 @@ const VideoCard = memo(
           },
         }}
       >
-        <Link
-          to={videoId ? `/video/${videoId}` : demoVideoUrl}
-          aria-label={`Open video ${title}`}
-        >
-          <CardMedia
-            image={snippet?.thumbnails?.high?.url}
-            alt={snippet?.title}
+        <Box sx={{ position: 'relative' }}>
+          <Link
+            to={videoId ? `/video/${videoId}` : demoVideoUrl}
+            aria-label={`Open video ${title}`}
+          >
+            <CardMedia
+              image={snippet?.thumbnails?.high?.url}
+              alt={snippet?.title}
+              sx={{
+                width: { xs: '100%', sm: '358px' },
+                height: 180,
+                transition: 'transform 0.3s ease',
+                '&:hover': {
+                  transform: 'scale(1.05)',
+                },
+              }}
+            />
+          </Link>
+          <IconButton
+            aria-label={
+              saved ? 'Remove from watch later' : 'Save to watch later'
+            }
+            onClick={handleToggle}
+            size="small"
             sx={{
-              width: { xs: '100%', sm: '358px' },
-              height: 180,
-              transition: 'transform 0.3s ease',
-              '&:hover': {
-                transform: 'scale(1.05)',
-              },
+              position: 'absolute',
+              bottom: 4,
+              right: 4,
+              bgcolor: 'rgba(0,0,0,0.7)',
+              color: saved ? 'primary.main' : '#fff',
+              '&:hover': { bgcolor: 'rgba(0,0,0,0.9)', opacity: 1 },
+              opacity: { xs: 1, sm: 0.9 },
             }}
-          />
-        </Link>
+          >
+            {saved ? (
+              <Bookmark fontSize="small" />
+            ) : (
+              <BookmarkBorder fontSize="small" />
+            )}
+          </IconButton>
+        </Box>
         <CardContent
           sx={{
             bgcolor: 'background.paper',

--- a/src/utils/watchLater.js
+++ b/src/utils/watchLater.js
@@ -1,0 +1,40 @@
+const STORAGE_KEY = 'yt_watch_later';
+
+export const getWatchLater = () => {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored ? JSON.parse(stored) : [];
+  } catch {
+    return [];
+  }
+};
+
+export const isInWatchLater = (videoId) => {
+  const list = getWatchLater();
+  return list.some((v) => v.id === videoId);
+};
+
+export const toggleWatchLater = (video) => {
+  const list = getWatchLater();
+  const existing = list.findIndex((v) => v.id === video.id);
+  if (existing >= 0) {
+    list.splice(existing, 1);
+  } else {
+    list.unshift({
+      id: video.id,
+      title: video.title,
+      channelTitle: video.channelTitle,
+      channelId: video.channelId,
+      thumbnail: video.thumbnail,
+      addedAt: new Date().toISOString(),
+    });
+  }
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(list));
+  } catch {
+    // quota exceeded, ignore
+  }
+  return existing < 0;
+};
+
+export const getWatchLaterCount = () => getWatchLater().length;


### PR DESCRIPTION
### Changes

- **Bookmark toggle on VideoCard**: Small icon button overlays each video thumbnail — click to save/remove from watch later. State persists in localStorage.

- **Watch later utility** (`utils/watchLater.js`): CRUD operations for a watch later list stored in localStorage, with same pattern as subscriptions.

- **You page section**: Watch later list displayed between subscriptions and recently watched, showing saved videos in a grid.

Closes #80