### PR TITLE
Phase 9 – Dark/light mode toggle

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy } from 'react';
+import { Suspense, lazy, useMemo } from 'react';
 import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom';
 import { Box, ThemeProvider } from '@mui/material';
 import CssBaseline from '@mui/material/CssBaseline';
@@ -12,7 +12,8 @@ import {
 import MobileBottomNav from './components/layout/MobileBottomNav';
 import { LoadingBarProvider } from './components/layout/TopLoadingBar';
 import { SidebarProvider } from './context/SidebarContext';
-import { theme } from './themes/';
+import { ThemeModeProvider, useThemeMode } from './context/ThemeModeContext';
+import { createAppTheme } from './themes/';
 
 const Feed = lazy(() => import('./components/routes/Feed'));
 const VideoDetail = lazy(() => import('./components/routes/VideoDetail'));
@@ -90,8 +91,11 @@ const AnimatedRoutes = () => {
   );
 };
 
-const App = () => (
-  <BrowserRouter>
+const ThemedApp = () => {
+  const { mode } = useThemeMode();
+  const theme = useMemo(() => createAppTheme(mode), [mode]);
+
+  return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
       <Box sx={{ backgroundColor: 'background.default' }}>
@@ -108,6 +112,14 @@ const App = () => (
         </AppErrorBoundary>
       </Box>
     </ThemeProvider>
+  );
+};
+
+const App = () => (
+  <BrowserRouter>
+    <ThemeModeProvider>
+      <ThemedApp />
+    </ThemeModeProvider>
   </BrowserRouter>
 );
 

--- a/src/components/layout/Navbar.jsx
+++ b/src/components/layout/Navbar.jsx
@@ -8,10 +8,17 @@ import {
   useMediaQuery,
   useTheme,
 } from '@mui/material';
-import { ArrowBack, NotificationsNone, Search } from '@mui/icons-material';
+import {
+  ArrowBack,
+  DarkMode,
+  LightMode,
+  NotificationsNone,
+  Search,
+} from '@mui/icons-material';
 
 import { logo } from '../../utils/constants';
 import SearchBar from './SearchBar';
+import { useThemeMode } from '../../context/ThemeModeContext';
 
 const Navbar = () => {
   const navigate = useNavigate();
@@ -19,6 +26,7 @@ const Navbar = () => {
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
   const [showSearch, setShowSearch] = useState(false);
   const [notifOpen, setNotifOpen] = useState(false);
+  const { mode, toggle: toggleTheme } = useThemeMode();
 
   const handleSearchClick = useCallback(() => {
     if (isMobile) {
@@ -83,6 +91,15 @@ const Navbar = () => {
         </Link>
 
         <Stack direction="row" alignItems="center" gap={0.5}>
+          <IconButton
+            aria-label={
+              mode === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'
+            }
+            onClick={toggleTheme}
+            sx={{ color: 'text.primary' }}
+          >
+            {mode === 'dark' ? <LightMode /> : <DarkMode />}
+          </IconButton>
           <IconButton
             aria-label="Notifications"
             onClick={() => setNotifOpen(true)}

--- a/src/context/ThemeModeContext.jsx
+++ b/src/context/ThemeModeContext.jsx
@@ -1,0 +1,30 @@
+import { createContext, useContext, useMemo } from 'react';
+import { usePersistedState } from '../hooks';
+
+const ThemeModeContext = createContext();
+
+export const ThemeModeProvider = ({ children }) => {
+  const [mode, setMode] = usePersistedState('yt_theme_mode', 'dark');
+
+  const value = useMemo(
+    () => ({
+      mode,
+      toggle: () => setMode((m) => (m === 'dark' ? 'light' : 'dark')),
+    }),
+    [mode, setMode]
+  );
+
+  return (
+    <ThemeModeContext.Provider value={value}>
+      {children}
+    </ThemeModeContext.Provider>
+  );
+};
+
+export const useThemeMode = () => {
+  const ctx = useContext(ThemeModeContext);
+  if (!ctx) {
+    throw new Error('useThemeMode must be used within ThemeModeProvider');
+  }
+  return ctx;
+};

--- a/src/themes/index.js
+++ b/src/themes/index.js
@@ -1,1 +1,1 @@
-export { default as theme } from './theme';
+export { createAppTheme } from './theme';

--- a/src/themes/theme.js
+++ b/src/themes/theme.js
@@ -1,110 +1,95 @@
 import { createTheme } from '@mui/material/styles';
 
-const theme = createTheme({
-  palette: {
-    mode: 'dark',
-    primary: {
-      main: '#F31503',
-      light: '#ff4d4d',
-      dark: '#cc0000',
+export const createAppTheme = (mode) =>
+  createTheme({
+    palette: {
+      mode,
+      primary: {
+        main: '#F31503',
+        light: '#ff4d4d',
+        dark: '#cc0000',
+      },
+      divider: mode === 'dark' ? '#3d3d3d' : '#e0e0e0',
+      background:
+        mode === 'dark'
+          ? { default: '#0f0f0f', paper: '#1e1e1e' }
+          : { default: '#f9f9f9', paper: '#ffffff' },
+      text:
+        mode === 'dark'
+          ? { primary: '#f1f1f1', secondary: '#aaaaaa' }
+          : { primary: '#0f0f0f', secondary: '#606060' },
+      custom:
+        mode === 'dark'
+          ? {
+              skeletonLight: '#2d2d2d',
+              skeletonMid: '#242424',
+              skeletonDark: '#1d1d1d',
+              verifiedBadge: '#8a8a8a',
+              focusOutline: '#ffb347',
+              searchBorder: '#e3e3e3',
+              channelCardBorder: '#e3e3e3',
+            }
+          : {
+              skeletonLight: '#e0e0e0',
+              skeletonMid: '#d0d0d0',
+              skeletonDark: '#c0c0c0',
+              verifiedBadge: '#606060',
+              focusOutline: '#ffb347',
+              searchBorder: '#ccc',
+              channelCardBorder: '#ccc',
+            },
     },
-    divider: '#3d3d3d',
-    background: {
-      default: '#0f0f0f',
-      paper: '#1e1e1e',
+    typography: {
+      fontFamily: '"Roboto", "Arial", sans-serif',
+      h4: { fontWeight: 700 },
+      h5: { fontWeight: 700 },
+      h6: { fontWeight: 600 },
+      subtitle1: { fontWeight: 700 },
+      subtitle2: { fontWeight: 700 },
     },
-    text: {
-      primary: '#f1f1f1',
-      secondary: '#aaaaaa',
-    },
-    custom: {
-      skeletonLight: '#2d2d2d',
-      skeletonMid: '#242424',
-      skeletonDark: '#1d1d1d',
-      verifiedBadge: '#8a8a8a',
-      focusOutline: '#ffb347',
-      searchBorder: '#e3e3e3',
-      channelCardBorder: '#e3e3e3',
-    },
-  },
-  typography: {
-    fontFamily: '"Roboto", "Arial", sans-serif',
-    h4: {
-      fontWeight: 700,
-    },
-    h5: {
-      fontWeight: 700,
-    },
-    h6: {
-      fontWeight: 600,
-    },
-    subtitle1: {
-      fontWeight: 700,
-    },
-    subtitle2: {
-      fontWeight: 700,
-    },
-  },
-  components: {
-    MuiCard: {
-      styleOverrides: {
-        root: {
-          boxShadow: 'none',
-          borderRadius: 0,
+    components: {
+      MuiCard: {
+        styleOverrides: {
+          root: { boxShadow: 'none', borderRadius: 0 },
         },
       },
-    },
-    MuiCardContent: {
-      styleOverrides: {
-        root: {
-          backgroundColor: '#1e1e1e',
-        },
-      },
-    },
-    MuiSkeleton: {
-      styleOverrides: {
-        root: {
-          backgroundColor: '#2d2d2d',
-        },
-      },
-    },
-    MuiButton: {
-      styleOverrides: {
-        contained: {
-          '&:hover': {
-            backgroundColor: '#cc0000',
+      MuiCardContent: {
+        styleOverrides: {
+          root: {
+            backgroundColor: mode === 'dark' ? '#1e1e1e' : '#ffffff',
           },
         },
       },
-    },
-    MuiCssBaseline: {
-      styleOverrides: {
-        body: {
-          scrollbarWidth: 'thin',
-          '&::-webkit-scrollbar': {
-            width: 0,
-            height: 5,
+      MuiSkeleton: {
+        styleOverrides: {
+          root: {
+            backgroundColor: mode === 'dark' ? '#2d2d2d' : '#e0e0e0',
           },
-          '&::-webkit-scrollbar-thumb': {
-            backgroundColor: 'rgb(114, 113, 113)',
-            borderRadius: 10,
-            height: 200,
+        },
+      },
+      MuiButton: {
+        styleOverrides: {
+          contained: {
+            '&:hover': { backgroundColor: '#cc0000' },
           },
-          '&::-webkit-scrollbar-track': {
-            backgroundColor: 'transparent',
-          },
-          '& a': {
-            textDecoration: 'none',
-            color: 'inherit',
-          },
-          '& a:focus-visible, & button:focus-visible, & input:focus-visible': {
-            outline: '3px solid #ffb347',
-            outlineOffset: 2,
+        },
+      },
+      MuiCssBaseline: {
+        styleOverrides: {
+          body: {
+            scrollbarWidth: 'thin',
+            '&::-webkit-scrollbar': { width: 0, height: 5 },
+            '&::-webkit-scrollbar-thumb': {
+              backgroundColor: 'rgb(114, 113, 113)',
+              borderRadius: 10,
+              height: 200,
+            },
+            '&::-webkit-scrollbar-track': { backgroundColor: 'transparent' },
+            '& a': { textDecoration: 'none', color: 'inherit' },
+            '& a:focus-visible, & button:focus-visible, & input:focus-visible':
+              { outline: '3px solid #ffb347', outlineOffset: 2 },
           },
         },
       },
     },
-  },
-});
-
-export default theme;
+  });


### PR DESCRIPTION
### Changes

- **Dynamic theme**: `theme.js` converted to a `createAppTheme(mode)` function that returns full dark or light palette/skeleton/background colors.

- **ThemeModeContext**: New context wrapping `usePersistedState` to persist the mode choice in localStorage (key: `yt_theme_mode`).

- **Toggle button**: Sun/moon icon button in the navbar — switches between dark and light mode.

- **App restructured**: `App.jsx` now renders `<ThemedApp>` inside `<ThemeModeProvider>` and `<BrowserRouter>`, with the theme re-created whenever mode changes.

Closes #82