### PR TITLE
Phase 10 – Fix SPA routing on Netlify

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,3 +5,8 @@
 [build.environment]
   CI = "true"
 
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200
+


### PR DESCRIPTION
### Changes

- Added [[redirects]] rule to netlify.toml: all paths serve /index.html with status 200 so client-side routing works on direct access or refresh.

Closes #84