### PR TITLE
Phase 13 – Named playlists

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,6 +22,7 @@ const SearchFeed = lazy(() => import('./components/routes/SearchFeed'));
 const Shorts = lazy(() => import('./components/routes/Shorts'));
 const Subscriptions = lazy(() => import('./components/routes/Subscriptions'));
 const You = lazy(() => import('./components/routes/You'));
+const PlaylistPage = lazy(() => import('./components/routes/PlaylistPage'));
 
 const AnimatedRoutes = () => {
   const location = useLocation();
@@ -83,6 +84,14 @@ const AnimatedRoutes = () => {
           element={
             <AnimatedPage>
               <You />
+            </AnimatedPage>
+          }
+        />
+        <Route
+          path="/playlist/:id"
+          element={
+            <AnimatedPage>
+              <PlaylistPage />
             </AnimatedPage>
           }
         />

--- a/src/components/routes/PlaylistPage.jsx
+++ b/src/components/routes/PlaylistPage.jsx
@@ -1,0 +1,75 @@
+import { useMemo } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { Box, IconButton, Typography } from '@mui/material';
+import { ArrowBack, Delete } from '@mui/icons-material';
+import { getPlaylist, deletePlaylist } from '../../utils/playlists';
+import { EmptyState, Videos } from '../';
+
+const toVideoItem = (v) => ({
+  id: { videoId: v.id },
+  snippet: {
+    title: v.title,
+    channelTitle: v.channelTitle,
+    channelId: v.channelId,
+    thumbnails: { high: { url: v.thumbnail } },
+  },
+});
+
+const PlaylistPage = () => {
+  const { id } = useParams();
+  const playlist = useMemo(() => getPlaylist(id), [id]);
+
+  if (!playlist) {
+    return (
+      <EmptyState
+        title="Playlist not found"
+        message="This playlist may have been deleted."
+      />
+    );
+  }
+
+  const videos = playlist.videos.map(toVideoItem);
+
+  return (
+    <Box component="main" p={2} sx={{ pb: { xs: 7, md: 2 } }}>
+      <Box display="flex" alignItems="center" gap={1} mb={2}>
+        <IconButton
+          component={Link}
+          to="/you"
+          aria-label="Back to You"
+          sx={{ color: 'text.primary' }}
+        >
+          <ArrowBack />
+        </IconButton>
+        <Box sx={{ flex: 1 }}>
+          <Typography variant="h5" fontWeight="bold" color="text.primary">
+            {playlist.name}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {playlist.videos.length} videos
+          </Typography>
+        </Box>
+        <IconButton
+          aria-label="Delete playlist"
+          onClick={() => {
+            deletePlaylist(id);
+          }}
+          component={Link}
+          to="/you"
+          sx={{ color: 'text.secondary' }}
+        >
+          <Delete />
+        </IconButton>
+      </Box>
+      {videos.length === 0 ? (
+        <Typography variant="body2" color="text.secondary">
+          No videos in this playlist yet.
+        </Typography>
+      ) : (
+        <Videos videos={videos} />
+      )}
+    </Box>
+  );
+};
+
+export default PlaylistPage;

--- a/src/components/routes/You.jsx
+++ b/src/components/routes/You.jsx
@@ -3,11 +3,13 @@ import { Box, Chip, Divider, Stack, Typography } from '@mui/material';
 import {
   Bookmark,
   History,
+  PlaylistPlay,
   Subscriptions as SubscriptionsIcon,
   VideoLibrary,
   Person,
 } from '@mui/icons-material';
 import { getRecentlyWatched } from '../../utils/recentlyWatched';
+import { getPlaylists } from '../../utils/playlists';
 import {
   getSubscriptions,
   getSubscriptionCount,
@@ -43,6 +45,7 @@ const You = () => {
   const subCount = useMemo(() => getSubscriptionCount(), []);
   const watchLater = useMemo(() => getWatchLater(), []);
   const wlCount = useMemo(() => getWatchLaterCount(), []);
+  const playlists = useMemo(() => getPlaylists(), []);
 
   return (
     <Box
@@ -121,6 +124,36 @@ const You = () => {
               >
                 <SubscriptionCard sub={sub} />
               </Box>
+            ))}
+          </Stack>
+        </Box>
+      )}
+
+      {playlists.length > 0 && (
+        <Box mb={3}>
+          <Typography
+            variant="h6"
+            fontWeight="bold"
+            mb={1}
+            sx={{ color: 'text.primary' }}
+          >
+            <PlaylistPlay
+              sx={{ fontSize: 20, verticalAlign: 'middle', mr: 0.5 }}
+            />
+            Playlists
+          </Typography>
+          <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+            {playlists.map((p) => (
+              <Chip
+                key={p.id}
+                label={`${p.name} (${p.videos.length})`}
+                component={Link}
+                to={`/playlist/${p.id}`}
+                icon={<PlaylistPlay />}
+                variant="outlined"
+                clickable
+                sx={{ borderRadius: 20 }}
+              />
             ))}
           </Stack>
         </Box>

--- a/src/components/shared/PlaylistMenu.jsx
+++ b/src/components/shared/PlaylistMenu.jsx
@@ -1,0 +1,109 @@
+import { useState } from 'react';
+import {
+  Button,
+  Dialog,
+  DialogTitle,
+  List,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+  Stack,
+  TextField,
+} from '@mui/material';
+import {
+  PlaylistAdd,
+  CheckCircleOutline,
+  CheckCircle,
+} from '@mui/icons-material';
+import {
+  getPlaylists,
+  createPlaylist,
+  addToPlaylist,
+  isInPlaylist,
+} from '../../utils/playlists';
+
+const PlaylistMenu = ({ open, onClose, video }) => {
+  const [playlists, setPlaylists] = useState(() => getPlaylists());
+  const [newName, setNewName] = useState('');
+  const [creating, setCreating] = useState(false);
+
+  const refresh = () => setPlaylists(getPlaylists());
+
+  const handleToggle = (playlistId) => {
+    if (isInPlaylist(playlistId, video.id)) {return;}
+    addToPlaylist(playlistId, video);
+    refresh();
+  };
+
+  const handleCreate = () => {
+    if (!newName.trim()) {return;}
+    const p = createPlaylist(newName.trim());
+    addToPlaylist(p.id, video);
+    setNewName('');
+    setCreating(false);
+    refresh();
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} maxWidth="xs" fullWidth>
+      <DialogTitle sx={{ color: 'text.primary' }}>Save to playlist</DialogTitle>
+      <List sx={{ pt: 0 }}>
+        {playlists.map((p) => {
+          const inList = isInPlaylist(p.id, video.id);
+          return (
+            <ListItemButton
+              key={p.id}
+              onClick={() => handleToggle(p.id)}
+              disabled={inList}
+            >
+              <ListItemIcon sx={{ minWidth: 36 }}>
+                {inList ? (
+                  <CheckCircle sx={{ color: 'primary.main', fontSize: 20 }} />
+                ) : (
+                  <CheckCircleOutline
+                    sx={{ color: 'text.secondary', fontSize: 20 }}
+                  />
+                )}
+              </ListItemIcon>
+              <ListItemText
+                primary={p.name}
+                primaryTypographyProps={{
+                  variant: 'body2',
+                  color: 'text.primary',
+                }}
+                secondary={`${p.videos.length} videos`}
+                secondaryTypographyProps={{ variant: 'caption' }}
+              />
+            </ListItemButton>
+          );
+        })}
+      </List>
+      {creating ? (
+        <Stack direction="row" spacing={1} sx={{ px: 3, pb: 2 }}>
+          <TextField
+            size="small"
+            placeholder="Playlist name"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
+            autoFocus
+            sx={{ flex: 1 }}
+          />
+          <Button variant="contained" size="small" onClick={handleCreate}>
+            Create
+          </Button>
+        </Stack>
+      ) : (
+        <Button
+          startIcon={<PlaylistAdd />}
+          onClick={() => setCreating(true)}
+          sx={{ mx: 2, mb: 2, textTransform: 'none' }}
+        >
+          New playlist
+        </Button>
+      )}
+    </Dialog>
+  );
+};
+
+export default PlaylistMenu;

--- a/src/components/video/VideoCard.jsx
+++ b/src/components/video/VideoCard.jsx
@@ -8,9 +8,15 @@ import {
   CardContent,
   CardMedia,
   IconButton,
+  Stack,
   Typography,
 } from '@mui/material';
-import { Bookmark, BookmarkBorder, CheckCircle } from '@mui/icons-material';
+import {
+  Bookmark,
+  BookmarkBorder,
+  CheckCircle,
+  PlaylistAdd,
+} from '@mui/icons-material';
 
 import { formatRelativeTime } from '../../utils/formatRelativeTime';
 import {
@@ -20,6 +26,7 @@ import {
   demoChannelTitle,
 } from '../../utils/constants';
 import { isInWatchLater, toggleWatchLater } from '../../utils/watchLater';
+import PlaylistMenu from '../shared/PlaylistMenu';
 
 const VideoCard = memo(
   ({
@@ -29,6 +36,7 @@ const VideoCard = memo(
     },
   }) => {
     const [saved, setSaved] = useState(isInWatchLater(videoId));
+    const [playlistOpen, setPlaylistOpen] = useState(false);
     const title = snippet?.title || demoVideoTitle;
     const channelTitle = snippet?.channelTitle || demoChannelTitle;
     const channelId = snippet?.channelId;
@@ -77,28 +85,63 @@ const VideoCard = memo(
               }}
             />
           </Link>
-          <IconButton
-            aria-label={
-              saved ? 'Remove from watch later' : 'Save to watch later'
-            }
-            onClick={handleToggle}
-            size="small"
+          <Stack
+            direction="row"
+            spacing={0.5}
             sx={{
               position: 'absolute',
               bottom: 4,
               right: 4,
-              bgcolor: 'rgba(0,0,0,0.7)',
-              color: saved ? 'primary.main' : '#fff',
-              '&:hover': { bgcolor: 'rgba(0,0,0,0.9)', opacity: 1 },
-              opacity: { xs: 1, sm: 0.9 },
             }}
           >
-            {saved ? (
-              <Bookmark fontSize="small" />
-            ) : (
-              <BookmarkBorder fontSize="small" />
-            )}
-          </IconButton>
+            <IconButton
+              aria-label={
+                saved ? 'Remove from watch later' : 'Save to watch later'
+              }
+              onClick={handleToggle}
+              size="small"
+              sx={{
+                bgcolor: 'rgba(0,0,0,0.7)',
+                color: saved ? 'primary.main' : '#fff',
+                '&:hover': { bgcolor: 'rgba(0,0,0,0.9)' },
+                opacity: { xs: 1, sm: 0.9 },
+              }}
+            >
+              {saved ? (
+                <Bookmark fontSize="small" />
+              ) : (
+                <BookmarkBorder fontSize="small" />
+              )}
+            </IconButton>
+            <IconButton
+              aria-label="Save to playlist"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                setPlaylistOpen(true);
+              }}
+              size="small"
+              sx={{
+                bgcolor: 'rgba(0,0,0,0.7)',
+                color: '#fff',
+                '&:hover': { bgcolor: 'rgba(0,0,0,0.9)' },
+                opacity: { xs: 1, sm: 0.9 },
+              }}
+            >
+              <PlaylistAdd fontSize="small" />
+            </IconButton>
+          </Stack>
+          <PlaylistMenu
+            open={playlistOpen}
+            onClose={() => setPlaylistOpen(false)}
+            video={{
+              id: videoId,
+              title,
+              channelTitle,
+              channelId,
+              thumbnail: snippet?.thumbnails?.high?.url,
+            }}
+          />
         </Box>
         <CardContent
           sx={{

--- a/src/utils/playlists.js
+++ b/src/utils/playlists.js
@@ -1,0 +1,85 @@
+const STORAGE_KEY = 'yt_playlists';
+
+const generateId = () =>
+  Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+
+export const getPlaylists = () => {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored ? JSON.parse(stored) : [];
+  } catch {
+    return [];
+  }
+};
+
+const savePlaylists = (playlists) => {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(playlists));
+  } catch {
+    // quota exceeded, ignore
+  }
+};
+
+export const createPlaylist = (name) => {
+  const playlists = getPlaylists();
+  const playlist = {
+    id: generateId(),
+    name,
+    videos: [],
+    createdAt: new Date().toISOString(),
+  };
+  playlists.push(playlist);
+  savePlaylists(playlists);
+  return playlist;
+};
+
+export const deletePlaylist = (playlistId) => {
+  const playlists = getPlaylists().filter((p) => p.id !== playlistId);
+  savePlaylists(playlists);
+};
+
+export const renamePlaylist = (playlistId, newName) => {
+  const playlists = getPlaylists();
+  const target = playlists.find((p) => p.id === playlistId);
+  if (target) {
+    target.name = newName;
+    savePlaylists(playlists);
+  }
+};
+
+export const getPlaylist = (playlistId) => {
+  const playlists = getPlaylists();
+  return playlists.find((p) => p.id === playlistId) || null;
+};
+
+export const isInPlaylist = (playlistId, videoId) => {
+  const playlist = getPlaylist(playlistId);
+  return playlist ? playlist.videos.some((v) => v.id === videoId) : false;
+};
+
+export const addToPlaylist = (playlistId, video) => {
+  const playlists = getPlaylists();
+  const target = playlists.find((p) => p.id === playlistId);
+  if (!target) {return false;}
+  if (target.videos.some((v) => v.id === video.id)) {return false;}
+  target.videos.push({
+    id: video.id,
+    title: video.title,
+    channelTitle: video.channelTitle,
+    channelId: video.channelId,
+    thumbnail: video.thumbnail,
+    addedAt: new Date().toISOString(),
+  });
+  savePlaylists(playlists);
+  return true;
+};
+
+export const removeFromPlaylist = (playlistId, videoId) => {
+  const playlists = getPlaylists();
+  const target = playlists.find((p) => p.id === playlistId);
+  if (!target) {return;}
+  target.videos = target.videos.filter((v) => v.id !== videoId);
+  savePlaylists(playlists);
+};
+
+export const getPlaylistCount = () => getPlaylists().length;


### PR DESCRIPTION
### Changes

- **Playlists utility** (`utils/playlists.js`): Full CRUD — create, rename, delete playlists; add/remove videos. Stored in localStorage.

- **Save menu** (`PlaylistMenu.jsx`): Dialog on every VideoCard showing existing playlists with checkmarks. Option to create and save to a new playlist in one step.

- **Playlist detail page** (`/playlist/:id`): Shows videos in a playlist with back and delete buttons.

- **You page section**: Playlists listed as clickable chips linking to the detail page.

- **Route added**: `/playlist/:id` lazy-loaded in App.jsx.

Closes #90