### PR TITLE
Phase 15 – Trending page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,7 @@ const Feed = lazy(() => import('./components/routes/Feed'));
 const VideoDetail = lazy(() => import('./components/routes/VideoDetail'));
 const ChannelDetail = lazy(() => import('./components/routes/ChannelDetail'));
 const SearchFeed = lazy(() => import('./components/routes/SearchFeed'));
+const Trending = lazy(() => import('./components/routes/Trending'));
 const Shorts = lazy(() => import('./components/routes/Shorts'));
 const Subscriptions = lazy(() => import('./components/routes/Subscriptions'));
 const You = lazy(() => import('./components/routes/You'));
@@ -68,6 +69,14 @@ const AnimatedRoutes = () => {
           element={
             <AnimatedPage>
               <Shorts />
+            </AnimatedPage>
+          }
+        />
+        <Route
+          path="/trending"
+          element={
+            <AnimatedPage>
+              <Trending />
             </AnimatedPage>
           }
         />

--- a/src/components/routes/Trending.jsx
+++ b/src/components/routes/Trending.jsx
@@ -1,0 +1,73 @@
+import { useCallback } from 'react';
+import { Box, CircularProgress, Typography } from '@mui/material';
+import { Whatshot } from '@mui/icons-material';
+import { fetchTrendingVideos } from '../../utils/fetchFromAPI';
+import { useInfiniteScroll } from '../../hooks';
+import { ErrorState, Videos, VideoGridSkeleton } from '../';
+
+const Trending = () => {
+  const loadVideos = useCallback(
+    (pageToken) => fetchTrendingVideos(pageToken),
+    []
+  );
+
+  const {
+    items: videos,
+    isLoading,
+    isLoadingMore,
+    errorMessage,
+    hasMore,
+    sentinelRef,
+    reload,
+  } = useInfiniteScroll({
+    loader: loadVideos,
+    fallbackErrorMessage: 'Unable to load trending videos.',
+  });
+
+  return (
+    <Box
+      component="main"
+      p={2}
+      sx={{ overflowY: 'auto', height: '90vh', pb: { xs: 7, md: 2 } }}
+    >
+      <Typography
+        component="h1"
+        variant="h4"
+        fontWeight="bold"
+        mb={2}
+        sx={{ color: 'text.primary' }}
+      >
+        <Whatshot
+          sx={{
+            fontSize: 34,
+            verticalAlign: 'middle',
+            mr: 1,
+            color: 'primary.main',
+          }}
+        />
+        Trending
+      </Typography>
+      {isLoading ? (
+        <VideoGridSkeleton count={8} />
+      ) : errorMessage ? (
+        <ErrorState
+          title="Unable to load trending videos"
+          message={errorMessage}
+          onRetry={reload}
+        />
+      ) : (
+        <>
+          <Videos videos={videos} />
+          {isLoadingMore && (
+            <Box display="flex" justifyContent="center" py={3}>
+              <CircularProgress size={28} sx={{ color: 'primary.main' }} />
+            </Box>
+          )}
+          {hasMore && <div ref={sentinelRef} style={{ height: 1 }} />}
+        </>
+      )}
+    </Box>
+  );
+};
+
+export default Trending;

--- a/src/components/shared/CategoryChips.jsx
+++ b/src/components/shared/CategoryChips.jsx
@@ -1,9 +1,11 @@
 import { memo } from 'react';
 import { Chip, Stack, useMediaQuery, useTheme } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
 import { categories } from '../../utils/constants';
 
 const CategoryChips = memo(({ selectedCategory, setSelectedCategory }) => {
   const theme = useTheme();
+  const navigate = useNavigate();
   const isMobile = useMediaQuery(theme.breakpoints.down('md'));
 
   if (!isMobile) {
@@ -29,7 +31,11 @@ const CategoryChips = memo(({ selectedCategory, setSelectedCategory }) => {
         <Chip
           key={category.name}
           label={category.name}
-          onClick={() => setSelectedCategory(category.name)}
+          onClick={() =>
+            category.route
+              ? navigate(category.route)
+              : setSelectedCategory(category.name)
+          }
           variant={category.name === selectedCategory ? 'filled' : 'outlined'}
           color={category.name === selectedCategory ? 'primary' : 'default'}
           sx={{

--- a/src/components/shared/Sidebar.jsx
+++ b/src/components/shared/Sidebar.jsx
@@ -1,45 +1,56 @@
 import { memo } from 'react';
 import { Stack } from '@mui/material';
+import { useNavigate } from 'react-router-dom';
 import { categories } from '../../utils/constants';
 
-const Sidebar = memo(({ selectedCategory, setSelectedCategory }) => (
-  <Stack
-    component="nav"
-    aria-label="Video categories"
-    direction="column"
-    sx={{
-      overflow: 'auto',
-      height: { sx: 'auto', md: '95%' },
-    }}
-  >
-    {categories.map((category) => (
-      <button
-        className="category-btn"
-        aria-pressed={category.name === selectedCategory}
-        onClick={() => setSelectedCategory(category.name)}
-        style={{
-          background: category.name === selectedCategory && '#F31503',
-          color: 'white',
-        }}
-        key={category.name}
-      >
-        <span
-          aria-hidden="true"
+const Sidebar = memo(({ selectedCategory, setSelectedCategory }) => {
+  const navigate = useNavigate();
+
+  return (
+    <Stack
+      component="nav"
+      aria-label="Video categories"
+      direction="column"
+      sx={{
+        overflow: 'auto',
+        height: { sx: 'auto', md: '95%' },
+      }}
+    >
+      {categories.map((category) => (
+        <button
+          className="category-btn"
+          aria-pressed={category.name === selectedCategory}
+          onClick={() =>
+            category.route
+              ? navigate(category.route)
+              : setSelectedCategory(category.name)
+          }
           style={{
-            color: category.name === selectedCategory ? 'white' : '#F31503',
-            marginRight: '15px',
+            background: category.name === selectedCategory && '#F31503',
+            color: 'white',
           }}
+          key={category.name}
         >
-          {category.icon}
-        </span>
-        <span
-          style={{ opacity: category.name === selectedCategory ? '1' : '0.8' }}
-        >
-          {category.name}
-        </span>
-      </button>
-    ))}
-  </Stack>
-));
+          <span
+            aria-hidden="true"
+            style={{
+              color: category.name === selectedCategory ? 'white' : '#F31503',
+              marginRight: '15px',
+            }}
+          >
+            {category.icon}
+          </span>
+          <span
+            style={{
+              opacity: category.name === selectedCategory ? '1' : '0.8',
+            }}
+          >
+            {category.name}
+          </span>
+        </button>
+      ))}
+    </Stack>
+  );
+});
 
 export default Sidebar;

--- a/src/utils/constants.jsx
+++ b/src/utils/constants.jsx
@@ -11,10 +11,12 @@ import GraphicEqIcon from '@mui/icons-material/GraphicEq';
 import TheaterComedyIcon from '@mui/icons-material/TheaterComedy';
 import FitnessCenterIcon from '@mui/icons-material/FitnessCenter';
 import DeveloperModeIcon from '@mui/icons-material/DeveloperMode';
+import TrendingUpIcon from '@mui/icons-material/TrendingUp';
 
 export const logo = 'https://i.ibb.co/s9Qys2j/logo.png';
 
 export const categories = [
+  { name: 'Trending', icon: <TrendingUpIcon />, route: '/trending' },
   { name: 'New', icon: <HomeIcon /> },
   { name: 'JS Mastery', icon: <CodeIcon /> },
   { name: 'Coding', icon: <CodeIcon /> },

--- a/src/utils/fetchFromAPI.js
+++ b/src/utils/fetchFromAPI.js
@@ -120,6 +120,14 @@ export const fetchSearchVideos = async (query, pageToken, type) => {
   return { items: data.items ?? [], nextPageToken: data.nextPageToken ?? null };
 };
 
+export const fetchTrendingVideos = async (pageToken) => {
+  const data = await fetchFromAPI(
+    'videos?part=snippet,statistics&chart=mostPopular&regionCode=US',
+    pageToken
+  );
+  return { items: data.items ?? [], nextPageToken: data.nextPageToken ?? null };
+};
+
 export const fetchVideoDetails = async (id) => {
   const data = await fetchFromAPI(`videos?part=snippet,statistics&id=${id}`);
   return data.items?.[0] ?? null;


### PR DESCRIPTION
### Changes

- **`fetchTrendingVideos`** (`utils/fetchFromAPI.js`): Uses `videos?part=snippet,statistics&chart=mostPopular&regionCode=US`, returns `{ items, nextPageToken }` matching `useInfiniteScroll`'s expected shape.

- **Trending page** (`/trending`): Modeled on SearchFeed — infinite scroll, skeleton loading, and error/retry states.

- **Navigation**: Added a `route` property to sidebar categories. `Trending` entry (desktop sidebar + mobile chips) now navigates to `/trending` instead of setting a category.

Closes #100